### PR TITLE
Add Windows batch script to set up and run the tool

### DIFF
--- a/run_caption_tool.bat
+++ b/run_caption_tool.bat
@@ -1,0 +1,19 @@
+@echo off
+rem Setup virtual environment and run the Caption Sync Tool
+
+setlocal
+
+set "REPO_DIR=%~dp0"
+set "VENV_DIR=%REPO_DIR%venv"
+
+if not exist "%VENV_DIR%" (
+    python -m venv "%VENV_DIR%"
+)
+
+call "%VENV_DIR%\Scripts\activate.bat"
+
+pip install -r "%REPO_DIR%requirements.txt"
+
+python "%REPO_DIR%scripts\caption_tool.py" %*
+
+endlocal


### PR DESCRIPTION
## Summary
- add `run_caption_tool.bat` to create and activate a venv, install requirements, and start the caption tool

## Testing
- `python -m py_compile scripts/caption_tool.py`

------
https://chatgpt.com/codex/tasks/task_e_688675dea510832b872842cea2cfb41f