### PR TITLE
Enhance caption tool to auto-process example videos

### DIFF
--- a/scripts/caption_tool.py
+++ b/scripts/caption_tool.py
@@ -213,5 +213,28 @@ if __name__ == "__main__":  # pragma: no cover
     if args.video:
         process_video(args.video, args.model, args.font_size, args.font)
     else:
-        print("No input video provided. Exiting.")
+        examples_dir = Path(__file__).resolve().parents[1] / "examples"
+        supported_exts = {
+            ".mp4",
+            ".mov",
+            ".avi",
+            ".mkv",
+            ".webm",
+            ".flv",
+            ".ogv",
+            ".m4v",
+        }
+
+        example_videos = [
+            p
+            for p in examples_dir.glob("*")
+            if p.suffix.lower() in supported_exts and p.is_file()
+        ]
+
+        if not example_videos:
+            print("No input video provided and no videos found in 'examples/'. Exiting.")
+        else:
+            for video in example_videos:
+                print(f"[+] Processing example video: {video.name}")
+                process_video(str(video), args.model, args.font_size, args.font)
 


### PR DESCRIPTION
## Summary
- process any supported video in `examples/` when no video path is given

## Testing
- `python -m py_compile scripts/caption_tool.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68867fc09cc0832bbf380984e24dd7bf