### PR TITLE
Fix textbbox call for Pillow

### DIFF
--- a/scripts/caption_tool.py
+++ b/scripts/caption_tool.py
@@ -55,7 +55,8 @@ def _create_text_clip(
 
     dummy = Image.new("RGBA", (1, 1))
     draw_dummy = ImageDraw.Draw(dummy)
-    text_width, text_height = draw_dummy.textsize(text, font=font_obj)
+    bbox = draw_dummy.textbbox((0, 0), text, font=font_obj)
+    text_width, text_height = bbox[2] - bbox[0], bbox[3] - bbox[1]
 
     img = Image.new(
         "RGBA",


### PR DESCRIPTION
## Summary
- use `textbbox` instead of removed `textsize`

## Testing
- `pytest -q` *(fails: module 'stable_whisper' has no attribute '-q')*

------
https://chatgpt.com/codex/tasks/task_e_688687377558832ba8c30391c9bef0ec