### PR TITLE
Improve caption font fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ If instructed or requested later, create a basic GUI using `PySimpleGUI` with:
 python scripts/caption_tool.py path/to/video.mp4 --font-size 192
 ```
 
+If the specified font is unavailable, the tool automatically falls back to
+``DejaVuSans.ttf``. Use the ``--font`` option to supply another font name or a
+path to a ``.ttf`` file.
+
 ---
 
 > This repo is fully prepped. Get to work, Codex. Do it clean. Deliver subtitles that sing 🎤

--- a/scripts/caption_tool.py
+++ b/scripts/caption_tool.py
@@ -51,7 +51,10 @@ def _create_text_clip(
     try:
         font_obj = ImageFont.truetype(font, font_size)
     except OSError:
-        font_obj = ImageFont.load_default()
+        try:
+            font_obj = ImageFont.truetype("DejaVuSans.ttf", font_size)
+        except OSError:
+            font_obj = ImageFont.load_default()
 
     dummy = Image.new("RGBA", (1, 1))
     draw_dummy = ImageDraw.Draw(dummy)


### PR DESCRIPTION
## Summary
- increase caption font reliability by falling back to DejaVuSans
- document fallback behaviour in README

## Testing
- `ruff check scripts/caption_tool.py | head`
- `pytest -q 2>&1 | head -n 20` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6886947bd7a0832b9327e1cb304cfc9b